### PR TITLE
Refactor: Move two services into a common .NET library for testability

### DIFF
--- a/SET09102/SET09102.Common/Contracts/IFirmwareService.cs
+++ b/SET09102/SET09102.Common/Contracts/IFirmwareService.cs
@@ -1,0 +1,5 @@
+﻿namespace SET09102.Common.Contracts;
+public interface IFirmwareService
+{
+    string GetNextVersion(string currentVersion);
+}

--- a/SET09102/SET09102.Common/Contracts/IMapService.cs
+++ b/SET09102/SET09102.Common/Contracts/IMapService.cs
@@ -1,0 +1,8 @@
+﻿namespace SET09102.Common.Contracts;
+
+public interface IMapService
+{
+    string GetDefaultUrl();
+
+    string GetMapUrl(double latitude, double longitude);
+}

--- a/SET09102/SET09102.Common/SET09102.Common.csproj
+++ b/SET09102/SET09102.Common/SET09102.Common.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/SET09102/SET09102.Common/Services/FirmwareService.cs
+++ b/SET09102/SET09102.Common/Services/FirmwareService.cs
@@ -1,0 +1,24 @@
+﻿using SET09102.Common.Contracts;
+
+namespace SET09102.Common.Services;
+
+public class FirmwareService : IFirmwareService
+{
+    public string GetNextVersion(string currentVersion)
+    {
+        var versionParts = currentVersion.Split('.');
+
+        if (versionParts.Length == 3)
+        {
+            if (int.TryParse(versionParts[0], out int major) &&
+                int.TryParse(versionParts[1], out int minor) &&
+                int.TryParse(versionParts[2], out int patch))
+            {
+                major++;
+                return $"{major}.0.0";
+            }
+        }
+
+        throw new Exception($"The firmware version was not in the expected format - {currentVersion}");
+    }
+}

--- a/SET09102/SET09102.Common/Services/GoogleMapService.cs
+++ b/SET09102/SET09102.Common/Services/GoogleMapService.cs
@@ -1,0 +1,10 @@
+﻿using SET09102.Common.Contracts;
+
+namespace SET09102.Services;
+
+public class GoogleMapService : IMapService
+{
+    public string GetDefaultUrl() => "https://maps.google.com/maps";
+
+    public string GetMapUrl(double latitude, double longitude) => $"https://maps.google.com/maps?q={latitude},{longitude}";
+}

--- a/SET09102/SET09102.UnitTests/FirmwareServiceTests.cs
+++ b/SET09102/SET09102.UnitTests/FirmwareServiceTests.cs
@@ -1,0 +1,40 @@
+﻿using SET09102.Common.Services;
+
+namespace SET09102.UnitTests;
+
+public class FirmwareServiceTests
+{
+    private readonly FirmwareService _firmwareService;
+
+    public FirmwareServiceTests()
+    {
+        _firmwareService = new FirmwareService();
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "2.0.0")]
+    [InlineData("1.0.1", "2.0.0")]
+    [InlineData("1.1.1", "2.0.0")]
+    [InlineData("1.2.3", "2.0.0")]
+    public void GetNextVersion_ValidVersion(string currentVersion, string expectedNextVersion)
+    {
+        // Act
+        var nextVersion = _firmwareService.GetNextVersion(currentVersion);
+
+        // Assert
+        Assert.Equal(expectedNextVersion, nextVersion);
+    }
+
+    [Theory]
+    [InlineData("abc.def.ghi")]
+    [InlineData("1.2")]   
+    [InlineData("")]
+    [InlineData("1..3")]
+    [InlineData("1.2.3.4")]
+    public void GetNextVersion_InvalidVersion_ThrowsException(string invalidVersion)
+    {
+        // Act & Assert
+        var ex = Assert.Throws<Exception>(() => _firmwareService.GetNextVersion(invalidVersion));
+        Assert.Contains("The firmware version was not in the expected format", ex.Message);
+    }
+}

--- a/SET09102/SET09102.UnitTests/GoogleMapServiceTests.cs
+++ b/SET09102/SET09102.UnitTests/GoogleMapServiceTests.cs
@@ -1,0 +1,36 @@
+﻿using SET09102.Services;
+
+namespace SET09102.UnitTests;
+
+public class GoogleMapServiceTests
+{
+    private readonly GoogleMapService _mapService;
+
+    public GoogleMapServiceTests()
+    {
+        _mapService = new GoogleMapService();
+    }
+
+    [Fact]
+    public void GetDefaultUrl_ReturnsExpectedUrl()
+    {
+        // Act
+        var url = _mapService.GetDefaultUrl();
+
+        // Assert
+        Assert.Equal("https://maps.google.com/maps", url);
+    }
+
+    [Theory]
+    [InlineData(37.7749, -122.4194, "https://maps.google.com/maps?q=37.7749,-122.4194")]
+    [InlineData(0, 0, "https://maps.google.com/maps?q=0,0")]
+    [InlineData(-90, 180, "https://maps.google.com/maps?q=-90,180")]
+    public void GetMapUrl_ReturnsCorrectUrl(double lat, double lng, string expectedUrl)
+    {
+        // Act
+        var url = _mapService.GetMapUrl(lat, lng);
+
+        // Assert
+        Assert.Equal(expectedUrl, url);
+    }
+}

--- a/SET09102/SET09102.UnitTests/SET09102.UnitTests.csproj
+++ b/SET09102/SET09102.UnitTests/SET09102.UnitTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SET09102.Common\SET09102.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/SET09102/SET09102.sln
+++ b/SET09102/SET09102.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35931.197 d17.13
+VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SET09102", "SET09102\SET09102.csproj", "{A38307C6-D43F-4C6E-931C-73BFAE0413D3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SET09102.UnitTests", "SET09102.UnitTests\SET09102.UnitTests.csproj", "{9225B340-5FCD-49A8-A933-C4C400B79090}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SET09102.Common", "SET09102.Common\SET09102.Common.csproj", "{480097CB-6AAF-4E41-96FD-F91D91D99015}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +19,14 @@ Global
 		{A38307C6-D43F-4C6E-931C-73BFAE0413D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A38307C6-D43F-4C6E-931C-73BFAE0413D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A38307C6-D43F-4C6E-931C-73BFAE0413D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9225B340-5FCD-49A8-A933-C4C400B79090}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9225B340-5FCD-49A8-A933-C4C400B79090}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9225B340-5FCD-49A8-A933-C4C400B79090}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9225B340-5FCD-49A8-A933-C4C400B79090}.Release|Any CPU.Build.0 = Release|Any CPU
+		{480097CB-6AAF-4E41-96FD-F91D91D99015}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{480097CB-6AAF-4E41-96FD-F91D91D99015}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{480097CB-6AAF-4E41-96FD-F91D91D99015}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{480097CB-6AAF-4E41-96FD-F91D91D99015}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SET09102/SET09102/EnvironmentalScientist/Pages/DisplayThresholdAlerts.xaml.cs
+++ b/SET09102/SET09102/EnvironmentalScientist/Pages/DisplayThresholdAlerts.xaml.cs
@@ -1,19 +1,23 @@
 using System.Collections.ObjectModel;
 using SET09102.Models;
 using SET09102.Services;
+using SET09102.Common.Contracts;
 
 namespace SET09102.EnvironmentalScientist.Pages
 {
     public partial class DisplayThresholdAlerts : ContentPage
     {
         private readonly ISensorService _sensorService;
+        private readonly IMapService _mapService;
         private ObservableCollection<SensorAlert> _sensorAlerts = [];
         private SensorAlert? _selectedSensorAlert = null;
-        private string _mapUrl = "https://maps.google.com/maps";
+        private string _mapUrl = string.Empty;
 
-        public DisplayThresholdAlerts(ISensorService sensorService)
+        public DisplayThresholdAlerts(ISensorService sensorService, IMapService mapService)
         {
             _sensorService = sensorService;
+            _mapService = mapService;
+            MapUrl = mapService.GetDefaultUrl();
             InitializeComponent();
             BindingContext = this;  // Set the binding context for data binding
             _ = LoadSensorsAlertsAsync();            
@@ -36,14 +40,10 @@ namespace SET09102.EnvironmentalScientist.Pages
             set
             {
                 _selectedSensorAlert = value;
-                if (_selectedSensorAlert == null)
-                {
-                    MapUrl = "https://maps.google.com/maps";
-                }
-                else
-                {
-                    MapUrl = $"https://maps.google.com/maps?q={_selectedSensorAlert.Sensor.Latitude},{_selectedSensorAlert.Sensor.Longitude}";
-                }
+                MapUrl =
+                    _selectedSensorAlert == null
+                        ? _mapService.GetDefaultUrl()
+                        : _mapService.GetMapUrl(_selectedSensorAlert.Sensor.Latitude, _selectedSensorAlert.Sensor.Longitude);
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(SensorAlertSelected));
                 OnPropertyChanged(nameof(NoSensorAlertSelected));

--- a/SET09102/SET09102/MauiProgram.cs
+++ b/SET09102/SET09102/MauiProgram.cs
@@ -1,4 +1,6 @@
 ﻿using SET09102.Services;
+using SET09102.Common.Services;
+using SET09102.Common.Contracts;
 using SET09102.Administrator.Pages;
 using SET09102.OperationsManager.Pages;
 
@@ -18,6 +20,8 @@ namespace SET09102
                 });
 
             // Register services
+            builder.Services.AddSingleton<IMapService, GoogleMapService>();
+            builder.Services.AddSingleton<IFirmwareService, FirmwareService>();
             builder.Services.AddSingleton<DatabaseService>();
             builder.Services.AddSingleton<ISensorService>(_ => new SensorService(new DatabaseService().GetDatabasePath()));
             builder.Services.AddSingleton<DataImportService>();            

--- a/SET09102/SET09102/SET09102.csproj
+++ b/SET09102/SET09102/SET09102.csproj
@@ -85,6 +85,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\SET09102.Common\SET09102.Common.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<None Update="SampleData\**">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>


### PR DESCRIPTION
- Extracted shared logic into a common library to improve reusability and enable unit testing
- Added a UnitTests project to the solution with initial test coverage